### PR TITLE
Add release notes

### DIFF
--- a/.github/workflows/BuildCommanderConda.yml
+++ b/.github/workflows/BuildCommanderConda.yml
@@ -27,7 +27,6 @@ jobs:
       checksum4: ${{ steps.bcd.outputs.out-3 }}
       checksum5: ${{ steps.bcd.outputs.out-4 }}
       checksum6: ${{ steps.bcd.outputs.out-5 }}
-      num_assets: ${{ strategy.job-count }}
     steps:
       - uses: actions/checkout@v2
       - uses: goanpeca/setup-miniconda@v1
@@ -97,30 +96,28 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    defaults:
-      run:
-        working-directory: artifact
     steps:
       - uses: actions/download-artifact@v2
       - name: Show artifacts
+        working-directory: artifact
         run: ls -RGla
       - name: Verify SHA256 Checksums
+        working-directory: artifact
         run: |
           for sum in *.sha256; do
             shasum -w -c "${sum}"
           done
           rm *.sha256
       - name: Check passed SHA256 checksums
+        working-directory: artifact
         run: |
-          echo "${{ needs.build.outputs.checksum1 }}" >> sha256-checksums.txt
-          echo "${{ needs.build.outputs.checksum2 }}" >> sha256-checksums.txt
-          echo "${{ needs.build.outputs.checksum3 }}" >> sha256-checksums.txt
-          echo "${{ needs.build.outputs.checksum4 }}" >> sha256-checksums.txt
-          echo "${{ needs.build.outputs.checksum5 }}" >> sha256-checksums.txt
-          echo "${{ needs.build.outputs.checksum6 }}" >> sha256-checksums.txt
+          echo -e "${{ join(needs.build.outputs.*, '\n') }}" > sha256-checksums.txt
           cat sha256-checksums.txt
           sha256sum -w -c sha256-checksums.txt
 
+      - name: Get notes from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: git cat-file -p ${GITHUB_REF#refs/tags/} | tail -n +6 | tee release-notes.txt
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
@@ -128,3 +125,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: 'artifact/*'
+          body_path: './release-notes.txt'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+In is anticipated that primarily [TAU Commander] developers will be contributing to this repository, although bug fixes from users are more than welcome.
+
+The default workflow is described on the main repository [README.md] page.
+To summarize, a new branch should be created in a [fork] for external contributors or simply a new topic branch for [TAU Commander] developers.
+Then a [pull request] against master should be opened.
+Once the [CI Tests] have passed (or commits made and pushed to resolve any issues) the PR is merged into master.
+Finally a [TAU Commander] developer can tag a new release at which point all of the binary distributions are included in a new release.
+
+__All contributors are expected to follow the [Code of Conduct]__
+
+[TAU Commander]: https://github.com/ParaToolsInc/taucmdr
+[README.md]: https://github.com/ParaToolsInc/CommanderConda#readme
+[pull request]: https://github.com/ParaToolsInc/CommanderConda/compare
+[CI Tests]: https://github.com/ParaToolsInc/CommanderConda/actions
+[fork]: https://github.com/ParaToolsInc/CommanderConda/fork
+[Code of Conduct]: https://github.com/ParaToolsInc/CommanderConda/blob/master/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
+<div align='center'>
+
 # CommanderConda
+
 Custom Conda distribution in support of TAU Commander
+
+</div>
+
+[![.github/workflows/BuildCommanderConda.yml][GHA badge]][workflow]
+[![GitHub release (latest SemVer)][Release badge]][latest]
+
+## About
+
+This repository defines a custom [Anaconda] Python distribution that is used by [TAU Commander].
+[TAU Commander] will automatically pick and use the correct custom [Anaconda] distribution;
+this project and repository is not intended to be of interest or of use to [TAU Commander] users.
+The packages included in the distribution are defined in the [construct.yaml] file.
+These packages must be kept in sync with [TAU Commander] development.
+[GitHub Actions] is used to automate the creation and release of this custom [Anaconda] distribution using [Constructor].
+The mechanisms for generating Python2 and Python3 packages using Jinja2 templating and distributions for multiple achitectures
+is based on the approach used by the [miniforge project].
+
+## [TAU Commander] Developers
+
+To create a new release please follow these steps:
+
+1. Make the appropriate changes to [construct.yaml] to include new/different packages on a new branch.
+2. Open a [pull request] against master.
+3. Ensure tests & build passes, push any needed fixes to the working branch.
+4. Merge the [pull request] into master.
+5. Create a new tag and ensure that it is an annotated tag by passing `-a` to `git tag` (or, better yet, GPG sign the tag with `-s` which implies `-a`).
+6. After CI/CD finishes running check that the [workflow] created [a new release][latest] using the tag message as the body of the release text.
+
+## Target Platforms and Status
+
+| Arch-OS \ Python Version | 2.7 | 3.7 |
+| --------------------: | :--: | :--: |
+| x86_64 Linux | Supported, implemented, deprecated | Supported, WIP |
+| x86_64 macOS | Supported, WIP, deprecated | Supported, WIP |
+| x86_64 Windows | Unsupported, deprecated | Unsupported |
+| aarch64 Linux | Supported, WIP, deprecated | Supported, WIP |
+| ppc64le Linux | Supported, WIP, deprecated | Supported, WIP |
+
+[GHA badge]: https://github.com/ParaToolsInc/CommanderConda/workflows/.github/workflows/BuildCommanderConda.yml/badge.svg
+[Release badge]: https://img.shields.io/github/v/release/ParaToolsInc/CommanderConda?sort=semver
+[workflow]: https://github.com/ParaToolsInc/CommanderConda/blob/master/.github/workflows/BuildCommanderConda.yml
+[latest]: https://github.com/ParaToolsInc/CommanderConda/releases/latest
+[TAU Commander]: https://github.com/ParaToolsInc/taucmdr
+[construct.yaml]: https://github.com/ParaToolsInc/CommanderConda/blob/master/CommanderConda/construct.yaml
+[GitHub Actions]: https://help.github.com/en/actions
+[Constructor]: https://github.com/conda/constructor
+[miniforge project]: https://github.com/conda-forge/miniforge
+[pull request]: https://github.com/ParaToolsInc/CommanderConda/pulls
+[Anaconda]: https://docs.conda.io/projects/conda/en/latest/

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,9 @@
+This directory is for utility, and template files.
+
+- [condarc.yml] holds a default `condarc` configuration that differs from the default only by showing channel urls.
+- [environment.yml] contains the conda packages needed to build and deploy the custom Commander Conda distribution.
+  - These *may NOT* be installed into the custom distribution; [construct.yaml] dictates what is included in the generated distribution.
+
+[condarc.yml]: ./condarc.yml
+[environment.yml]: ./environment.yml
+[construct.yaml]: ../CommanderConda/construct.yaml


### PR DESCRIPTION
Changes:

- Auto releasing from tags now adds the tag's notes/annotation as the body of the release notes (untested until new tag created)
- Main workflow simplified a little bit
- Documentation improved including READMEs and CONTRIBUTING.md