### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/BuildCommanderConda.yml
+++ b/.github/workflows/BuildCommanderConda.yml
@@ -87,7 +87,7 @@ jobs:
           echo "${MINIFORGE_SHA256} *${MINIFORGE_FILE}" | tee ${MINIFORGE_FILE}.sha256
           shasum -c ./${MINIFORGE_FILE}.sha256
       - name: Build and test CommanderConda
-        run: export GITHUB_REF && ./build_CommanderConda_${{ runner.os }}.sh
+        run: ./build_CommanderConda_${{ runner.os }}.sh
       - name: Checksum Outputs
         id: cksums
         working-directory: build

--- a/.github/workflows/BuildCommanderConda.yml
+++ b/.github/workflows/BuildCommanderConda.yml
@@ -87,7 +87,7 @@ jobs:
           echo "${MINIFORGE_SHA256} *${MINIFORGE_FILE}" | tee ${MINIFORGE_FILE}.sha256
           shasum -c ./${MINIFORGE_FILE}.sha256
       - name: Build and test CommanderConda
-        run: ./build_CommanderConda_${{ runner.os }}.sh
+        run: export GITHUB_REF && ./build_CommanderConda_${{ runner.os }}.sh
       - name: Checksum Outputs
         id: cksums
         working-directory: build

--- a/.github/workflows/BuildCommanderConda.yml
+++ b/.github/workflows/BuildCommanderConda.yml
@@ -150,7 +150,7 @@ jobs:
           git for-each-ref --format='%(contents)' "${GITHUB_REF}" | sed '/BEGIN PGP SIGNATURE/,/END PGP SIGNATURE/d' | tee release-notes.txt
           printf '\n---\n' >> release-notes.txt
           git for-each-ref --format='Tagged: %(taggername) on %(taggerdate:rfc2822)' "${GITHUB_REF}" | tee -a release-notes.txt
-          git for-each-ref --format='Commit: %(objectname)' "${GITHUB_REF}" | tee -a release-notes.txt
+          git rev-list -n 1 "${GITHUB_REF}" | tee -a release-notes.txt
           printf 'Released by [@%s](https://github.com/%s)' "${GITHUB_ACTOR}" "${GITHUB_ACTOR}" >> release-notes.txt
           cat release-notes.txt
       - name: Release

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -24,10 +24,15 @@ specs:
 {% endif %}
   - six
   - termcolor
-#  - texttable
+  - texttable
 #  - tinydb
 #  - unidecode
   - wcwidth
+
+# Don't bloat tagged (released) binary distributions with unneeded stuff
+{% if not os.environ.get("GITHUB_REF", "")[0:10] == "refs/tags/" %}
+keep_pkgs: True
+{% endif %}
 
 initialize_by_default: False
 

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -26,7 +26,7 @@ specs:
   - termcolor
   - texttable
   - tinydb
-  # - unidecode
+  - unidecode
   - wcwidth
 
 initialize_by_default: False

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -25,8 +25,8 @@ specs:
   - six
   - termcolor
   - texttable
-#  - tinydb
-#  - unidecode
+  - tinydb
+  - unidecode
   - wcwidth
 
 initialize_by_default: False

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -25,7 +25,7 @@ specs:
   - six
   - termcolor
   - texttable
-  - tinydb
+#  - tinydb
   - unidecode
   - wcwidth
 

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -24,9 +24,9 @@ specs:
 {% endif %}
   - six
   - termcolor
-  - texttable
-  - tinydb
-  - unidecode
+  # - texttable
+  # - tinydb
+  # - unidecode
   - wcwidth
 
 initialize_by_default: False

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -25,7 +25,7 @@ specs:
   - six
   - termcolor
   - texttable
-#  - tinydb
+  - tinydb
   - unidecode
   - wcwidth
 

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -14,9 +14,6 @@ channels:
 specs:
   - bzip2
   - conda {{ version.split("-")[0] }}
-{% if not os.environ.get("GITHUB_REF", "")[0:10] == "refs/tags/" %}
-  - conda-build
-{% endif %}
   - fasteners
   - monotonic
   - pip
@@ -31,11 +28,6 @@ specs:
 #  - tinydb
 #  - unidecode
   - wcwidth
-
-# Don't bloat tagged (released) binary distributions with unneeded stuff
-{% if not os.environ.get("GITHUB_REF", "")[0:10] == "refs/tags/" %}
-keep_pkgs: True
-{% endif %}
 
 initialize_by_default: False
 

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -14,6 +14,9 @@ channels:
 specs:
   - bzip2
   - conda {{ version.split("-")[0] }}
+{% if not os.environ.get("GITHUB_REF", "")[0:10] == "refs/tags/" %}
+  - conda-build
+{% endif %}
   - fasteners
   - monotonic
   - pip

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -25,7 +25,7 @@ specs:
   - six
   - termcolor
   - texttable
-  # - tinydb
+  - tinydb
   # - unidecode
   - wcwidth
 

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -24,7 +24,7 @@ specs:
 {% endif %}
   - six
   - termcolor
-  # - texttable
+  - texttable
   # - tinydb
   # - unidecode
   - wcwidth

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -8,7 +8,7 @@ set -o nounset
 case "${ARCH}" in
     x86_64)
         DOCKER_ARCH=amd64
-        DOCKERIMAGE=condaforge/linux-anvil-cos7-x86_64
+        DOCKERIMAGE=condaforge/linux-anvil-comp7:9bef6c41d7add4c09327280582da0e53905a2f9ea1ba151e751c
         ;;
     ppc64le)
         DOCKER_ARCH=ppc64le

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -8,7 +8,7 @@ set -o nounset
 case "${ARCH}" in
     x86_64)
         DOCKER_ARCH=amd64
-        DOCKERIMAGE=condaforge/linux-anvil-comp7@sha256:88138de6129f9bef6c41d7add4c09327280582da0e53905a2f9ea1ba151e751c
+        DOCKERIMAGE=condaforge/linux-anvil-comp7 # @sha256:88138de6129f9bef6c41d7add4c09327280582da0e53905a2f9ea1ba151e751c
         ;;
     ppc64le)
         DOCKER_ARCH=ppc64le

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -8,7 +8,7 @@ set -o nounset
 case "${ARCH}" in
     x86_64)
         DOCKER_ARCH=amd64
-        DOCKERIMAGE=condaforge/linux-anvil-comp7:9bef6c41d7add4c09327280582da0e53905a2f9ea1ba151e751c
+        DOCKERIMAGE=condaforge/linux-anvil-comp7@sha256:88138de6129f9bef6c41d7add4c09327280582da0e53905a2f9ea1ba151e751c
         ;;
     ppc64le)
         DOCKER_ARCH=ppc64le

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -8,7 +8,7 @@ set -o nounset
 case "${ARCH}" in
     x86_64)
         DOCKER_ARCH=amd64
-        DOCKERIMAGE=condaforge/linux-anvil-comp7
+        DOCKERIMAGE=condaforge/linux-anvil-comp7:88138de6129f
         ;;
     ppc64le)
         DOCKER_ARCH=ppc64le

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -32,11 +32,11 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset --crede
 
 echo "============= Build the installer ============="
 # See github actions issue #241 comment here: https://github.com/actions/runner/issues/241#issuecomment-577360161
-script -e -c "docker run --rm -ti -v $(pwd):/construct -e ARCH -e COMMANDERCONDA_VERSION -e COMMANDERCONDA_NAME $DOCKERIMAGE /construct/scripts/build.sh"
+script -e -c "docker run --rm -ti -v $(pwd):/construct -e GITHUB_REF -e ARCH -e COMMANDERCONDA_VERSION -e COMMANDERCONDA_NAME $DOCKERIMAGE /construct/scripts/build.sh"
 
 echo "============= Test the installer ============="
 for TEST_IMAGE_NAME in "ubuntu:20.04" "ubuntu:16.04" "ubuntu:18.04" "centos:7" "debian:buster" "opensuse:42.3"
 do
   echo "============= Test installer on $TEST_IMAGE_NAME ============="
-  script -e -c "docker run --rm -ti -v $(pwd):/construct -v $(pwd)/build/qemu/qemu-${ARCH}-static:/usr/bin/qemu-${ARCH}-static -e ARCH ${DOCKER_ARCH}/$TEST_IMAGE_NAME /construct/scripts/test.sh"
+  script -e -c "docker run --rm -ti -v $(pwd):/construct -v $(pwd)/build/qemu/qemu-${ARCH}-static:/usr/bin/qemu-${ARCH}-static -e GITHUB_REF -e ARCH ${DOCKER_ARCH}/$TEST_IMAGE_NAME /construct/scripts/test.sh"
 done

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -35,7 +35,7 @@ echo "============= Build the installer ============="
 script -e -c "docker run --rm -ti -v $(pwd):/construct -e ARCH -e COMMANDERCONDA_VERSION -e COMMANDERCONDA_NAME $DOCKERIMAGE /construct/scripts/build.sh"
 
 echo "============= Test the installer ============="
-for TEST_IMAGE_NAME in "ubuntu:19.10" "ubuntu:16.04" "ubuntu:18.04" "centos:7" "debian:buster"
+for TEST_IMAGE_NAME in "ubuntu:20.04" "ubuntu:16.04" "ubuntu:18.04" "centos:7" "debian:buster" "opensuse:42.3"
 do
   echo "============= Test installer on $TEST_IMAGE_NAME ============="
   script -e -c "docker run --rm -ti -v $(pwd):/construct -v $(pwd)/build/qemu/qemu-${ARCH}-static:/usr/bin/qemu-${ARCH}-static -e ARCH ${DOCKER_ARCH}/$TEST_IMAGE_NAME /construct/scripts/test.sh"

--- a/build_CommanderConda_Linux.sh
+++ b/build_CommanderConda_Linux.sh
@@ -8,7 +8,7 @@ set -o nounset
 case "${ARCH}" in
     x86_64)
         DOCKER_ARCH=amd64
-        DOCKERIMAGE=condaforge/linux-anvil-comp7:88138de6129f
+        DOCKERIMAGE=condaforge/linux-anvil-cos7-x86_64
         ;;
     ppc64le)
         DOCKER_ARCH=ppc64le

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,9 +1,0 @@
-This directory is for utility, and template files.
-
-- [condarc.yml] holds a default `condarc` configuration that differs from the default only by showing channel urls.
-- [environment.yml] contains the conda packages needed to build and deploy the custom Commander Conda distribution.
-  - These *may NOT* be installed into the custom distribution; [construct.yaml] dictates what is included in the generated distribution.
-
-[condarc.yml]: ./condarc.yml
-[environment.yml]: ./environment.yml
-[construct.yaml]: ../CommanderConda/construct.yaml

--- a/etc/condarc.yml
+++ b/etc/condarc.yml
@@ -1,6 +1,0 @@
-# Show channel URLs when displaying what is going to be downloaded
-# and in 'conda list'. The default is False.
-show_channel_urls: True
-
-# For more information about this file see:
-# https://conda.io/docs/user-guide/configuration/use-condarc.html

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -1,9 +1,0 @@
-name: constructor-env
-channels:
-  - defaults
-  - conda-forge
-dependencies:
-  - conda-build
-  - constructor>=3.0.1
-  - jinja2
-  - openssl

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -52,4 +52,10 @@ python -c "import platform; print(platform.machine())"
 python -c "import platform; import os; assert platform.machine() in os.environ.get('ARCH')"
 python -c "import platform; print(platform.release())"
 
+# Import the important packages from CommanderConda
+python -c "import fasteners; import six; from termcolor import termcolor; from texttable import Texttable"
+
+# Print the zen of python
+python -c "import this"
+
 echo "***** Done: Building Testing installer *****"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,10 +56,11 @@ python -c "import platform; print(platform.release())"
 python -c \
        "import fasteners; \
         import six; \
-        import termcolor;" # \
-#        from texttable import Texttable; \
+        import termcolor; \
+        from texttable import Texttable;" # \
 #        import tinydb; \
 #        from unidecode import unidecode"
+
 
 # Print the zen of python
 python -c "import this"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,9 +56,8 @@ python -c "import platform; print(platform.release())"
 python -c \
        "import fasteners; \
         import six; \
-        from termcolor import termcolor; \
+        import termcolor; \
         from texttable import Texttable; \
-        import tinydb; \
         from unidecode import unidecode"
 
 # Print the zen of python

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,10 +56,10 @@ python -c "import platform; print(platform.release())"
 python -c \
        "import fasteners; \
         import six; \
-        import termcolor; \
-        from texttable import Texttable; \
-        import tinydb; \
-        from unidecode import unidecode"
+        import termcolor;" # \
+#        from texttable import Texttable; \
+#        import tinydb; \
+#        from unidecode import unidecode"
 
 # Print the zen of python
 python -c "import this"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,8 +58,10 @@ python -c \
         import six; \
         import termcolor; \
         from texttable import Texttable; \
-        import tinydb;" # \
-#        from unidecode import unidecode"
+        import tinydb; \
+        from unidecode import unidecode"
+
+
 
 
 # Print the zen of python

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,6 +58,7 @@ python -c \
         import six; \
         import termcolor; \
         from texttable import Texttable; \
+        import tinydb; \
         from unidecode import unidecode"
 
 # Print the zen of python

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,7 +53,11 @@ echo "***** Print system information from Python *****"
 python -c "print('Hello CommanderConda!')"
 python -c "import platform; print(platform.architecture())"
 python -c "import platform; print(platform.system())"
+THIS_OS="$(uname)"
+export THIS_OS
+python -c "import platform; import os; assert platform.system() in os.environ.get('THIS_OS')"
 python -c "import platform; print(platform.machine())"
+python -c "import platform; import os; assert platform.machine() in os.environ.get('ARCH')"
 python -c "import platform; print(platform.release())"
 
 echo "***** Done: Building Testing installer *****"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,13 +18,7 @@ INSTALLER_PATH=$(find build/ -name "CommanderConda*$ARCH.sh" | head -n 1)
 
 echo "***** Run the installer *****"
 chmod +x "$INSTALLER_PATH"
-
-if ! [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
-    echo "***** Performing install and self-tests *****"
-    "$INSTALLER_PATH" -b -u -t -p "$CONDA_PATH"
-else
-    "$INSTALLER_PATH" -b -u -p "$CONDA_PATH"
-fi
+"$INSTALLER_PATH" -b -u -p "$CONDA_PATH"
 
 echo "***** Setup conda *****"
 set +o nounset

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,9 +19,7 @@ INSTALLER_PATH=$(find build/ -name "CommanderConda*$ARCH.sh" | head -n 1)
 echo "***** Run the installer *****"
 chmod +x "$INSTALLER_PATH"
 
-echo "GITHUB_REF: ${GITHUB_REF}"
-
-if [[ "${GITHUB_REF:-}" =~ refs/tags/ ]]; then
+if ! [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
     echo "***** Performing install and self-tests *****"
     "$INSTALLER_PATH" -b -u -t -p "$CONDA_PATH"
 else

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -57,8 +57,8 @@ python -c \
        "import fasteners; \
         import six; \
         import termcolor; \
-        from texttable import Texttable;" # \
-#        import tinydb; \
+        from texttable import Texttable; \
+        import tinydb;" # \
 #        from unidecode import unidecode"
 
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,7 +53,13 @@ python -c "import platform; import os; assert platform.machine() in os.environ.g
 python -c "import platform; print(platform.release())"
 
 # Import the important packages from CommanderConda
-python -c "import fasteners; import six; from termcolor import termcolor; from texttable import Texttable"
+python -c \
+       "import fasteners; \
+        import six; \
+        from termcolor import termcolor; \
+        from texttable import Texttable; \
+        import tinydb; \
+        from unidecode import unidecode"
 
 # Print the zen of python
 python -c "import this"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,15 @@ INSTALLER_PATH=$(find build/ -name "CommanderConda*$ARCH.sh" | head -n 1)
 
 echo "***** Run the installer *****"
 chmod +x "$INSTALLER_PATH"
-bash "$INSTALLER_PATH" -b -p "$CONDA_PATH"
+
+echo "GITHUB_REF: ${GITHUB_REF}"
+
+if [[ "${GITHUB_REF:-}" =~ refs/tags/ ]]; then
+    echo "***** Performing install and self-tests *****"
+    "$INSTALLER_PATH" -b -u -t -p "$CONDA_PATH"
+else
+    "$INSTALLER_PATH" -b -u -p "$CONDA_PATH"
+fi
 
 echo "***** Setup conda *****"
 set +o nounset


### PR DESCRIPTION
Changes:

1. Remove unneeded `etc` directory and contents (obsolete since v1.0.0)
2. Fix commit hash of tag in release notes
3. Add back:
   - texttable
   - tinydb
   - unidecode
4. Pass `GITHUB_REF` to docker images so that construct.yml has access
5. Test on Ubuntu 20.04 instead of 19.10 and test on OpenSUSE
6. Improve quality of tests to at least import all modules