### PR TITLE
Turn off install in dependency order

### DIFF
--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -51,6 +51,8 @@ install_in_dependency_order: False
 
 # installer_type: pkg    [osx]
 
+keep_pkgs: True
+
 license_file: ../LICENSE
 
 register_python_default: False    [win]

--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -47,7 +47,7 @@ specs:
 
 initialize_by_default: False
 
-install_in_dependency_order: True
+install_in_dependency_order: False
 
 # installer_type: pkg    [osx]
 


### PR DESCRIPTION
Experiment to see if allowing out-of-dependency-order installation  works & speeds up CI

I may also see if other tips/tricks from condaforge can port over, and add a little more documentation.