### PR TITLE
Add dash-bootstrap-components

### DIFF
--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -25,6 +25,7 @@ specs:
   - bzip2
   - conda {{ version.split("-")[0] }}
   - dash 1.19
+  - dash-bootstrap-components
   - fasteners
   - ipykernel
   - ipywidgets 7.6.*


### PR DESCRIPTION
Added `dash-bootstrap-components` to contruct.yaml. Required for Tau Commander JupyterLab Extension.