### PR TITLE
Remove `install_in_dependency_order` construct key

### DIFF
--- a/CommanderConda/construct.yaml
+++ b/CommanderConda/construct.yaml
@@ -48,8 +48,6 @@ specs:
 
 initialize_by_default: False
 
-install_in_dependency_order: False
-
 # installer_type: pkg    [osx]
 
 keep_pkgs: True


### PR DESCRIPTION
* Fixes #20.
* `install_in_dependency_order` was deprecated by construct